### PR TITLE
Remove logic forcing login to FWS AGOL portal

### DIFF
--- a/GrassCarpQAQC.html
+++ b/GrassCarpQAQC.html
@@ -87,7 +87,6 @@
 
             const activeCreds = new OAuthInfo({
                 appId: "YJmzOVei1kPsElhn",
-                portalUrl: activePortal.url,
             });
 
             IdentityManager.registerOAuthInfos([activeCreds]);

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 This repository is for hosting single page web applications for USFWS offices that utilize ArcGIS Online for authentication and data storage.  These apps are built using [GitHub Pages](https://pages.github.com/).
 
 # [Grass Carp QA/QC](/GrassCarpQAQC.html)
-This app (requested by Jessica Bowser) allows collaborators who are submitting surveys to the Grass Carp Survey123 app to review their submissions and verify them.  Verification in this context means that the data submitted does not need corrections and can be reviewed by the data managers for accuracy.
+This app (requested by Jessica Bowser) allows collaborators who are submitting surveys to the Grass Carp Survey123 app to review their submissions and verify them.  Verification in this context means that the data submitted does not need corrections and can be reviewed by the data managers for accuracy.  Last updated 5/3/2024.


### PR DESCRIPTION
This will allow external users to log in and see the app if it is shared with them

Close #8 